### PR TITLE
Update makefile.pret

### DIFF
--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -1,6 +1,6 @@
 @prefix deps:  <http://ontologi.es/doap-deps#> .
 
 <http://purl.org/NET/cpan-uri/dist/MooseX-Declare-Context-WithOptions-Patch-Extensible/project>
-	deps:runtime-requirement         [ deps:on "MooseX::Declare 0.30"^^deps:CpanId ];
+	deps:runtime-requirement         [ deps:on "MooseX::Declare 0.39"^^deps:CpanId ];
 	deps:test-requirement            [ deps:on "Test::More 0.61"^^deps:CpanId ].
 


### PR DESCRIPTION
MooseX::Declare 0.30 doesn't export $VERSION, which causes the build to fail with:

```
Running make test
PERL_DL_NONLAZY=1 "/opt/local/bin/perl5.12" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01basic.t .... 1/1 
#   Failed test 'use MooseX::Declare::Context::WithOptions::Patch::Extensible;'
#   at t/01basic.t line 2.
#     Tried to use 'MooseX::Declare::Context::WithOptions::Patch::Extensible'.
#     Error:  MooseX::Declare::Context::WithOptions does not define $MooseX::Declare::Context::WithOptions::VERSION--version check failed at /Users/alex/.cpanm/work/1422131014.31290/MooseX-Declare-Context-WithOptions-Patch-Extensible-0.002/blib/lib/MooseX/Declare/Context/WithOptions/Patch/Extensible.pm line 18.
# BEGIN failed--compilation aborted at /Users/alex/.cpanm/work/1422131014.31290/MooseX-Declare-Context-WithOptions-Patch-Extensible-0.002/blib/lib/MooseX/Declare/Context/WithOptions/Patch/Extensible.pm line 18.
# Compilation failed in require at t/01basic.t line 2.
# BEGIN failed--compilation aborted at t/01basic.t line 2.
# Looks like you failed 1 test of 1.
t/01basic.t .... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 
t/02options.t .. MooseX::Declare::Context::WithOptions does not define $MooseX::Declare::Context::WithOptions::VERSION--version check failed at /Users/alex/.cpanm/work/1422131014.31290/MooseX-Declare-Context-WithOptions-Patch-Extensible-0.002/blib/lib/MooseX/Declare/Context/WithOptions/Patch/Extensible.pm line 18.
BEGIN failed--compilation aborted at /Users/alex/.cpanm/work/1422131014.31290/MooseX-Declare-Context-WithOptions-Patch-Extensible-0.002/blib/lib/MooseX/Declare/Context/WithOptions/Patch/Extensible.pm line 18.
Compilation failed in require at t/02options.t line 2.
BEGIN failed--compilation aborted at t/02options.t line 2.
t/02options.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run 

Test Summary Report
-------------------
t/01basic.t  (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
t/02options.t (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
Files=2, Tests=1,  2 wallclock secs ( 0.03 usr  0.02 sys +  1.43 cusr  0.12 csys =  1.60 CPU)
Result: FAIL
Failed 2/2 test programs. 1/1 subtests failed.
```

Installing MooseX::Declare 0.39 fixed this issue for me; this is on OSX 10.10.1 using perl 5.12.5
